### PR TITLE
Serde support added.

### DIFF
--- a/tom256/Cargo.toml
+++ b/tom256/Cargo.toml
@@ -12,12 +12,15 @@ num-bigint = { package = "num-bigint", version = "0.4.3", default-features = fal
 num-integer = { version = "0.1", default-features = false }
 rand_core = { version = "0.6.3", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
+serde = { version = "1", features = ["derive"], default-features = false }
+serdect = "0.1.0"
 sha3 = "0.10.1"
 wasm-bindgen = "0.2.80"
 
 [dev-dependencies]
 criterion = "0.3.5"
 rand = { version = "0.8.5", features = ["std"] }
+serde_json = "1"
 
 [[bench]]
 name = "point_mul"

--- a/tom256/src/arithmetic/field.rs
+++ b/tom256/src/arithmetic/field.rs
@@ -2,17 +2,17 @@ use super::modular::{mod_u256, Modular};
 use super::Scalar;
 use crate::{Curve, Cycle, U256};
 
+use bigint::Encoding;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::marker::PhantomData;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct FieldElement<C: Curve>(pub(crate) U256, pub(crate) PhantomData<C>);
+pub struct FieldElement<C>(pub(crate) U256, pub(crate) PhantomData<C>);
 
 impl<C: Curve> FieldElement<C> {
     pub const ONE: Self = Self(U256::ONE, PhantomData);
     pub const ZERO: Self = Self(U256::ZERO, PhantomData);
-}
 
-impl<C: Curve> FieldElement<C> {
     pub fn to_cycle_scalar<CC: Cycle<C>>(&self) -> Scalar<CC> {
         Scalar::<CC>::new(self.0)
     }
@@ -27,6 +27,26 @@ impl<C: Curve> Modular for FieldElement<C> {
 
     fn inner(&self) -> &U256 {
         &self.0
+    }
+}
+
+impl<'de, C: Curve> Deserialize<'de> for FieldElement<C> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut buffer = [0; 32];
+        serdect::array::deserialize_hex_or_bin(&mut buffer, deserializer)?;
+        Ok(Self::new(U256::from_le_bytes(buffer)))
+    }
+}
+
+impl<C: Curve> Serialize for FieldElement<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serdect::array::serialize_hex_lower_or_bin(&self.0.to_le_bytes(), serializer)
     }
 }
 
@@ -215,5 +235,16 @@ mod test {
         let a_min_b = a - b;
         let b_min_a = b - a;
         assert_eq!(a_min_b, -b_min_a);
+    }
+
+    #[test]
+    fn serde_round() {
+        let le_hex = "ce7c73f82cc708b9080499663f89fda1fa7bb76d78b72b4042554f33e418b94f";
+        let fe = FieldElement(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
+
+        let serialized = serde_json::to_string(&fe).unwrap();
+        assert_eq!(&serialized.as_bytes()[1..65], le_hex.as_bytes()); // serde puts the string between quotes
+        let deserialized = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(fe, deserialized);
     }
 }

--- a/tom256/src/arithmetic/point.rs
+++ b/tom256/src/arithmetic/point.rs
@@ -3,6 +3,7 @@ use super::modular::{mul_mod_u256, Modular};
 use super::scalar::Scalar;
 use crate::{Curve, U256};
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
@@ -11,7 +12,7 @@ const BASE_16_DIGITS: [char; 16] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
 ];
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Point<C: Curve> {
     x: FieldElement<C>,
     y: FieldElement<C>,

--- a/tom256/src/arithmetic/scalar.rs
+++ b/tom256/src/arithmetic/scalar.rs
@@ -2,7 +2,9 @@ use super::modular::{mod_u256, random_mod_u256, Modular};
 use crate::{Curve, U256};
 use rand_core::{CryptoRng, RngCore};
 
-use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use bigint::Encoding;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::{Ord, Ordering, PartialOrd};
 use std::marker::PhantomData;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -62,6 +64,26 @@ impl<C: Curve> Modular for Scalar<C> {
 
     fn inner(&self) -> &U256 {
         &self.0
+    }
+}
+
+impl<'de, C: Curve> Deserialize<'de> for Scalar<C> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut buffer = [0; 32];
+        serdect::array::deserialize_hex_or_bin(&mut buffer, deserializer)?;
+        Ok(Self::new(U256::from_le_bytes(buffer)))
+    }
+}
+
+impl<C: Curve> Serialize for Scalar<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serdect::array::serialize_hex_lower_or_bin(&self.0.to_le_bytes(), serializer)
     }
 }
 
@@ -350,5 +372,16 @@ mod test {
         assert_eq!(b * b.inverse(), ScalarLarge::ONE);
         b = ScalarLarge::new(Secp256k1::GENERATOR_X);
         assert_eq!(b * b.inverse(), ScalarLarge::ONE);
+    }
+
+    #[test]
+    fn serde_round() {
+        let le_hex = "ce7c73f82cc708b9080499663f89fda1fa7bb76d78b72b4042554f33e418b94f";
+        let fe = Scalar(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
+
+        let serialized = serde_json::to_string(&fe).unwrap();
+        assert_eq!(&serialized.as_bytes()[1..65], le_hex.as_bytes()); // serde puts the string between quotes
+        let deserialized = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(fe, deserialized);
     }
 }

--- a/tom256/src/proofs/equality.rs
+++ b/tom256/src/proofs/equality.rs
@@ -5,10 +5,11 @@ use crate::utils::PointHasher;
 use crate::Curve;
 
 use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EqualityProof<C: Curve> {
     commitment_to_random_1: Point<C>,
     commitment_to_random_2: Point<C>,

--- a/tom256/src/proofs/membership.rs
+++ b/tom256/src/proofs/membership.rs
@@ -6,7 +6,9 @@ use crate::utils::PointHasher;
 use crate::{Curve, U256};
 
 use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MembershipProof<C: Curve> {
     cl: Vec<Point<C>>,
     ca: Vec<Point<C>>,

--- a/tom256/src/proofs/multiplication.rs
+++ b/tom256/src/proofs/multiplication.rs
@@ -4,11 +4,12 @@ use crate::pedersen::*;
 use crate::utils::PointHasher;
 use crate::Curve;
 
+use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+
 use std::ops::Neg;
 
-use rand_core::{CryptoRng, RngCore};
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MultiplicationProof<C: Curve> {
     c4: Point<C>,
     commitment_to_random_1: Point<C>,

--- a/tom256/src/proofs/point_add.rs
+++ b/tom256/src/proofs/point_add.rs
@@ -7,6 +7,7 @@ use super::equality::EqualityProof;
 use super::multiplication::MultiplicationProof;
 
 use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 #[derive(Clone)]
@@ -72,6 +73,7 @@ impl<C: Curve> PointAddCommitments<C> {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PointAddCommitmentPoints<C: Curve> {
     px: Point<C>,
     py: Point<C>,
@@ -101,6 +103,7 @@ impl<C: Curve> PointAddCommitmentPoints<C> {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MultCommitProof<C: Curve> {
     commitment: Point<C>,
     proof: MultiplicationProof<C>,
@@ -112,6 +115,7 @@ impl<C: Curve> MultCommitProof<C> {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PointAddProof<CC: Cycle<C>, C: Curve> {
     mult_proof_8: MultCommitProof<CC>,
     mult_proof_10: MultCommitProof<CC>,


### PR DESCRIPTION
## Description
All proofs now implement `Serialize` and `Deserialize`. There might be some public commitments that need `serde` as well, but that can be added later when needed. Closes #8 