### PR TITLE
I9 multimult eval

### DIFF
--- a/tom256/src/arithmetic/multimult.rs
+++ b/tom256/src/arithmetic/multimult.rs
@@ -10,7 +10,7 @@ use rand_core::{CryptoRng, RngCore};
 use std::fmt;
 
 // Maximum iterations within the multimult evaluate() before terminating,
-// although infinite loops should not occur 
+// although infinite loops should not occur
 // Exp_proof verifications usually take less than 20_000 iterations
 const MULTIMULT_EVAL_MAX_ITERATIONS: usize = 50_000;
 
@@ -117,7 +117,6 @@ impl<C: Curve> MultiMult<C> {
                 pairs_heap.push(c);
             }
         }
-        
     }
 }
 

--- a/tom256/src/proofs/equality.rs
+++ b/tom256/src/proofs/equality.rs
@@ -160,22 +160,26 @@ mod test {
         );
 
         let invalid_pedersen_generator = PedersenGenerator::new(&mut rng);
-        assert!(equality_proof.verify(
-            &mut rng,
-            &invalid_pedersen_generator,
-            secret_commitment_1.commitment(),
-            secret_commitment_2.commitment(),
-        ).is_err());
+        assert!(equality_proof
+            .verify(
+                &mut rng,
+                &invalid_pedersen_generator,
+                secret_commitment_1.commitment(),
+                secret_commitment_2.commitment(),
+            )
+            .is_err());
 
         let invalid_secret = Scalar::<Tom256k1>::random(&mut rng);
         let invalid_secret_commitment_1 = pedersen_generator.commit(&mut rng, invalid_secret);
         let invalid_secret_commitment_2 = pedersen_generator.commit(&mut rng, invalid_secret);
 
-        assert!(equality_proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            invalid_secret_commitment_1.commitment(),
-            invalid_secret_commitment_2.commitment(),
-        ).is_err());
+        assert!(equality_proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                invalid_secret_commitment_1.commitment(),
+                invalid_secret_commitment_2.commitment(),
+            )
+            .is_err());
     }
 }

--- a/tom256/src/proofs/exp.rs
+++ b/tom256/src/proofs/exp.rs
@@ -339,8 +339,8 @@ impl<CC: Cycle<C>, C: Curve> ExpProof<C, CC> {
             }
         }
 
-        let tom_res = tom_multimult.evaluate();
-        let base_res = base_multimult.evaluate();
+        let tom_res = tom_multimult.evaluate()?;
+        let base_res = base_multimult.evaluate()?;
 
         if !(tom_res.is_identity() && base_res.is_identity()) {
             return Err("proof is invalid".to_owned());
@@ -464,15 +464,15 @@ mod test {
         )
         .unwrap();
 
-        assert!(exp_proof
-            .verify(
-                &mut rng,
-                &base_pedersen_generator,
-                &tom_pedersen_generator,
-                &commitments,
-                security_param,
-            )
-            .is_ok())
+        let exp_verify_result = exp_proof
+        .verify(
+            &mut rng,
+            &base_pedersen_generator,
+            &tom_pedersen_generator,
+            &commitments,
+            security_param,
+        );
+        assert!(exp_verify_result.is_ok());
     }
 
     #[test]

--- a/tom256/src/proofs/exp.rs
+++ b/tom256/src/proofs/exp.rs
@@ -464,8 +464,7 @@ mod test {
         )
         .unwrap();
 
-        let exp_verify_result = exp_proof
-        .verify(
+        let exp_verify_result = exp_proof.verify(
             &mut rng,
             &base_pedersen_generator,
             &tom_pedersen_generator,

--- a/tom256/src/proofs/membership.rs
+++ b/tom256/src/proofs/membership.rs
@@ -220,7 +220,7 @@ impl<C: Curve> MembershipProof<C> {
         rel_final.insert(pedersen_generator.generator().clone(), -self.zd);
         rel_final.drain(rng, &mut multimult);
 
-        if multimult.evaluate() == Point::IDENTITY {
+        if multimult.evaluate()? == Point::IDENTITY {
             Ok(())
         } else {
             Err("failed to verify membership".to_owned())

--- a/tom256/src/proofs/multiplication.rs
+++ b/tom256/src/proofs/multiplication.rs
@@ -215,13 +215,15 @@ mod test {
             z,
         );
 
-        assert!(multiplication_proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            commitment_x.commitment(),
-            commitment_y.commitment(),
-            commitment_z.commitment(),
-        ).is_ok());
+        assert!(multiplication_proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                commitment_x.commitment(),
+                commitment_y.commitment(),
+                commitment_z.commitment(),
+            )
+            .is_ok());
     }
 
     #[test]
@@ -247,45 +249,53 @@ mod test {
         );
 
         let invalid_pedersen_generator = PedersenGenerator::new(&mut rng);
-        assert!(multiplication_proof.verify(
-            &mut rng,
-            &invalid_pedersen_generator,
-            commitment_x.commitment(),
-            commitment_y.commitment(),
-            commitment_z.commitment(),
-        ).is_err());
+        assert!(multiplication_proof
+            .verify(
+                &mut rng,
+                &invalid_pedersen_generator,
+                commitment_x.commitment(),
+                commitment_y.commitment(),
+                commitment_z.commitment(),
+            )
+            .is_err());
 
         let invalid_x = Scalar::<Tom256k1>::random(&mut rng);
         let invalid_commitment_x = pedersen_generator.commit(&mut rng, invalid_x);
 
-        assert!(multiplication_proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            invalid_commitment_x.commitment(),
-            commitment_y.commitment(),
-            commitment_z.commitment(),
-        ).is_err());
+        assert!(multiplication_proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                invalid_commitment_x.commitment(),
+                commitment_y.commitment(),
+                commitment_z.commitment(),
+            )
+            .is_err());
 
         let invalid_y = Scalar::<Tom256k1>::random(&mut rng);
         let invalid_commitment_y = pedersen_generator.commit(&mut rng, invalid_y);
 
-        assert!(multiplication_proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            commitment_x.commitment(),
-            invalid_commitment_y.commitment(),
-            commitment_z.commitment(),
-        ).is_err());
+        assert!(multiplication_proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                commitment_x.commitment(),
+                invalid_commitment_y.commitment(),
+                commitment_z.commitment(),
+            )
+            .is_err());
 
         let invalid_z = z + Scalar::ONE;
         let invalid_commitment_z = pedersen_generator.commit(&mut rng, invalid_z);
 
-        assert!(multiplication_proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            commitment_x.commitment(),
-            commitment_y.commitment(),
-            invalid_commitment_z.commitment(),
-        ).is_err());
+        assert!(multiplication_proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                commitment_x.commitment(),
+                commitment_y.commitment(),
+                invalid_commitment_z.commitment(),
+            )
+            .is_err());
     }
 }

--- a/tom256/src/proofs/point_add.rs
+++ b/tom256/src/proofs/point_add.rs
@@ -337,11 +337,13 @@ mod test {
 
         let proof = PointAddProof::construct(&mut rng, &pedersen_generator, &commitments, &secret);
 
-        assert!(proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            &commitments.into_commitments()
-        ).is_ok());
+        assert!(proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                &commitments.into_commitments()
+            )
+            .is_ok());
     }
 
     #[test]
@@ -357,11 +359,13 @@ mod test {
 
         let proof = PointAddProof::construct(&mut rng, &pedersen_generator, &commitments, &secret);
 
-        assert!(proof.verify(
-            &mut rng,
-            &pedersen_generator,
-            &commitments.into_commitments()
-        ).is_err());
+        assert!(proof
+            .verify(
+                &mut rng,
+                &pedersen_generator,
+                &commitments.into_commitments()
+            )
+            .is_err());
     }
 
     // NOTE: Turning this test on probably fails due to the multimult iteration cap


### PR DESCRIPTION
# Description

Aims to resolve #9 . Added a comfortable upper limit to `MultiMult::evaluate` iteration. The function now returns a `Result` which is handled on all uses.