### PR TITLE
Proofs use is_identity

### DIFF
--- a/tom256/src/proofs/equality.rs
+++ b/tom256/src/proofs/equality.rs
@@ -104,7 +104,7 @@ impl<C: Curve> EqualityProof<C> {
             commitment_2,
             &mut multimult,
         );
-        multimult.evaluate() == Point::<C>::IDENTITY
+        multimult.evaluate().is_identity()
     }
 }
 

--- a/tom256/src/proofs/membership.rs
+++ b/tom256/src/proofs/membership.rs
@@ -220,7 +220,7 @@ impl<C: Curve> MembershipProof<C> {
         rel_final.insert(pedersen_generator.generator().clone(), -self.zd);
         rel_final.drain(rng, &mut multimult);
 
-        if multimult.evaluate() == Point::IDENTITY {
+        if multimult.evaluate().is_identity() {
             Ok(())
         } else {
             Err("failed to verify membership".to_owned())

--- a/tom256/src/proofs/multiplication.rs
+++ b/tom256/src/proofs/multiplication.rs
@@ -179,7 +179,7 @@ impl<C: Curve> MultiplicationProof<C> {
             commitment_to_z,
             &mut multimult,
         );
-        multimult.evaluate() == Point::<C>::IDENTITY
+        multimult.evaluate().is_identity()
     }
 }
 

--- a/tom256/src/proofs/point_add.rs
+++ b/tom256/src/proofs/point_add.rs
@@ -296,7 +296,7 @@ impl<CC: Cycle<C>, C: Curve> PointAddProof<CC, C> {
     ) -> bool {
         let mut multimult = MultiMult::new();
         self.aggregate(rng, pedersen_generator, commitments, &mut multimult);
-        multimult.evaluate() == Point::<CC>::IDENTITY
+        multimult.evaluate().is_identity()
     }
 }
 
@@ -384,6 +384,6 @@ mod test {
                 &mut multimult,
             );
         }
-        assert_eq!(multimult.evaluate(), Point::IDENTITY);
+        assert!(multimult.evaluate().is_identity());
     }
 }


### PR DESCRIPTION
# Description

Aims to resolve #11 . All proof verification now uses `is_identity()` instead of ` == Point::IDENTITY`