### PR TITLE
I10 exp pointadd

### DIFF
--- a/tom256/src/proofs/exp.rs
+++ b/tom256/src/proofs/exp.rs
@@ -179,12 +179,6 @@ impl<CC: Cycle<C>, C: Curve> ExpProof<C, CC> {
                     q: secrets.point.clone(),
                     r: t.into_affine(),
                 };
-                // TODO manually
-                let mut add_commitments = add_secret.commit(rng, tom_pedersen_generator);
-                add_commitments.qx = commitments.px.clone();
-                add_commitments.qy = commitments.py.clone();
-                add_commitments.rx = tx.clone();
-                add_commitments.ry = ty.clone();
 
                 let add_commitments = PointAddCommitments {
                     px: tom_pedersen_generator.commit(rng, t1_aff.x().to_cycle_scalar()),

--- a/tom256/src/proofs/point_add.rs
+++ b/tom256/src/proofs/point_add.rs
@@ -29,6 +29,7 @@ impl<C: Curve> PointAddSecrets<C> {
         }
     }
 
+    #[allow(unused)]
     pub fn commit<R, CC>(
         &self,
         rng: &mut R,


### PR DESCRIPTION
# Description

Aims to resolve #10 .

`PointAddSecrets'` and `PointAddCommitments'` members are now `pub(crate)`. `PointAddCommitments` are now constructed manually in point exponentiation proofs.