### PR TITLE
Hashing is done in the same fashion as ethers and metamask does.

### DIFF
--- a/tom256/examples/prover.rs
+++ b/tom256/examples/prover.rs
@@ -26,17 +26,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut rng = OsRng;
     let pedersen = PedersenCycle::<Secp256k1, Tom256k1>::new(&mut rng);
 
-    let msg_hash = "0x2c31a901b06d2727f458c7eb5c15eb7a794d69f841970f95c39ac092274c2a5a".to_string();
-    let pubkey =
-            "0x041296d6ed4e96bc378b8a460de783cdfbf58afbe04b355f1c225fb3e0b92cdc6e349d7005833c933898e2b88eae1cf40250c16352ace3915de65ec86f5bb9b349".to_string();
-    let signature =
-            "0xc945f22f92bc9afa7c8929637d3f8694b95a6ae9e276103b2061a0f88d61d8e92aaa9b9eec482d8befd1e1d2a9e2e219f21bd660278aefa9b0641184280cc2d91b".to_string();
+    let msg_hash = "0x9788117298a1450f6002d25f0c21d83bc6001681a2e5e31c748c0f55504b11e9".to_string();
+    let pubkey = "0454e32170dd5a0b7b641aa77daa1f3f31b8df17e51aaba6cfcb310848d26351180b6ac0399d21460443d10072700b64b454d70bfba5e93601536c740bbd099682".to_string();
+    let signature = "0xd2943d5fa0ba2733bcbbd58853c6c1be65388d9198dcb5228e117f49409612a46394afb97a7610d16e7bea0062e71afc2a3039324c80df8ef38d3668164fad2c1c".to_string();
 
     let proof_input = ProofInput {
         msg_hash,
         pubkey,
         signature,
-        index: 7,
+        index: 1,
         guild_id: "almafa".to_string(),
     };
 

--- a/tom256/src/proofs/mod.rs
+++ b/tom256/src/proofs/mod.rs
@@ -24,6 +24,7 @@ const SEC_PARAM: usize = 60;
 #[cfg(test)]
 const SEC_PARAM: usize = 10;
 
+const MSG_PREFIX: &str = "\x19Ethereum Signed Message:\n";
 const JOIN_GUILD_MSG: &str = "#zkp/join.guild.xyz/";
 
 /// Zero-knowledge proof consisting of an ECDSA and a Groth-Kohlweiss
@@ -116,7 +117,9 @@ impl<C: Curve, CC: Cycle<C>> ZkAttestProof<C, CC> {
         }
 
         let expected_msg = JOIN_GUILD_MSG.to_string() + &self.guild_id;
-        let hasher = PointHasher::new(expected_msg.as_bytes());
+        let expected_msg_len = expected_msg.as_bytes().len().to_string();
+        let preimage = format!("{}{}{}", MSG_PREFIX, expected_msg_len, expected_msg);
+        let hasher = PointHasher::new(preimage.as_bytes());
         let expected_hash = Scalar::<C>::new(hasher.finalize());
         if expected_hash != self.msg_hash {
             return Err("Signed message hash mismatch".to_string());
@@ -161,21 +164,21 @@ mod test {
         let pedersen_cycle = PedersenCycle::<Secp256k1, Tom256k1>::new(&mut rng);
 
         let msg_hash =
-            "0x2c31a901b06d2727f458c7eb5c15eb7a794d69f841970f95c39ac092274c2a5a".to_string();
-        let pubkey =
-            "0x041296d6ed4e96bc378b8a460de783cdfbf58afbe04b355f1c225fb3e0b92cdc6e349d7005833c933898e2b88eae1cf40250c16352ace3915de65ec86f5bb9b349".to_string();
-        let signature =
-            "0xc945f22f92bc9afa7c8929637d3f8694b95a6ae9e276103b2061a0f88d61d8e92aaa9b9eec482d8befd1e1d2a9e2e219f21bd660278aefa9b0641184280cc2d91b".to_string();
+            "0x9788117298a1450f6002d25f0c21d83bc6001681a2e5e31c748c0f55504b11e9".to_string();
+        let pubkey = "0454e32170dd5a0b7b641aa77daa1f3f31b8df17e51aaba6cfcb310848d26351180b6ac0399d21460443d10072700b64b454d70bfba5e93601536c740bbd099682".to_string();
+        let signature = "0xd2943d5fa0ba2733bcbbd58853c6c1be65388d9198dcb5228e117f49409612a46394afb97a7610d16e7bea0062e71afc2a3039324c80df8ef38d3668164fad2c1c".to_string();
 
         let ring = vec![
+            "c2ef144b59081382387f0ebf5d96b3a194f8c28961fa443000ea793ce534dac2".to_string(),
+            "54e32170dd5a0b7b641aa77daa1f3f31b8df17e51aaba6cfcb310848d2635118".to_string(), // our pubkey x
             "ddd40afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172".to_string(),
             "ccc50afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172".to_string(),
-            "1296d6ed4e96bc378b8a460de783cdfbf58afbe04b355f1c225fb3e0b92cdc6e".to_string(), // our pubkey x
+            "1296d6ed4e96bc378b8a460de783cdfbf58afbe04b355f1c225fb3e0b92cdc6e".to_string(),
             "aaa70afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172".to_string(),
             "bbb80afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172".to_string(),
         ];
 
-        let index = 2;
+        let index = 1;
 
         let proof_input = ProofInput {
             msg_hash,


### PR DESCRIPTION
## Description
Hotfix for cleaning up hashes. Note: Metamask hashes the signed message internally so no need to hash manually.