### PR TITLE
CryptoCoreRng trait added

### DIFF
--- a/tom256/Cargo.toml
+++ b/tom256/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 bigint = { package = "crypto-bigint", git = "https://github.com/PopcornPaws/crypto-bigint", default-features = false }
 num-bigint = { package = "num-bigint", version = "0.4.3", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-rand = { version = "0.8.5", features = ["std"] }
 rand_core = { version = "0.6.3", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1", features = ["derive"], default-features = false }
@@ -20,6 +19,7 @@ wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
 
 [dev-dependencies]
 criterion = "0.3.5"
+rand = { version = "0.8.5", features = ["std"] }
 serde_json = "1"
 structopt = "0.3.26"
 

--- a/tom256/Cargo.toml
+++ b/tom256/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 bigint = { package = "crypto-bigint", git = "https://github.com/PopcornPaws/crypto-bigint", default-features = false }
 num-bigint = { package = "num-bigint", version = "0.4.3", default-features = false }
 num-integer = { version = "0.1", default-features = false }
+rand = { version = "0.8.5", features = ["std"] }
 rand_core = { version = "0.6.3", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1", features = ["derive"], default-features = false }
@@ -19,7 +20,6 @@ wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
 
 [dev-dependencies]
 criterion = "0.3.5"
-rand = { version = "0.8.5", features = ["std"] }
 serde_json = "1"
 structopt = "0.3.26"
 

--- a/tom256/examples/exp_proof.rs
+++ b/tom256/examples/exp_proof.rs
@@ -3,11 +3,10 @@ use tom256::curve::{Secp256k1, Tom256k1};
 use tom256::pedersen::PedersenCycle;
 use tom256::proofs::{ExpProof, ExpSecrets};
 
-use rand::rngs::StdRng;
-use rand_core::SeedableRng;
+use rand_core::OsRng;
 
 fn main() {
-    let mut rng = StdRng::from_seed([14; 32]);
+    let mut rng = OsRng;
     let base_gen = Point::<Secp256k1>::GENERATOR;
     let pedersen_cycle = PedersenCycle::<Secp256k1, Tom256k1>::new(&mut rng);
 

--- a/tom256/src/arithmetic/modular.rs
+++ b/tom256/src/arithmetic/modular.rs
@@ -1,8 +1,8 @@
+use crate::rng::CryptoCoreRng;
 use bigint::subtle::ConstantTimeLess;
 use bigint::{Encoding, NonZero, U256};
 use num_bigint::BigUint;
 use num_integer::Integer;
-use rand_core::{CryptoRng, RngCore};
 
 const TWO: U256 = U256::from_u8(2);
 
@@ -90,13 +90,13 @@ fn exp_mod_u256(base: &U256, exponent: &U256, modulus: &U256) -> U256 {
     r
 }
 
-fn get_random_u256<R: CryptoRng + RngCore>(rng: &mut R) -> U256 {
+fn get_random_u256<R: CryptoCoreRng>(rng: &mut R) -> U256 {
     let mut bytes = [0_u8; 32];
     rng.fill_bytes(&mut bytes);
     U256::from_be_slice(&bytes)
 }
 
-pub fn random_mod_u256<T: Modular, R: CryptoRng + RngCore>(rng: &mut R) -> T {
+pub fn random_mod_u256<T: Modular, R: CryptoCoreRng>(rng: &mut R) -> T {
     loop {
         let random_number = get_random_u256(rng);
         if random_number.ct_lt(&T::MODULUS).into() {
@@ -356,7 +356,7 @@ mod random_test {
 
     // assumed: mod_byte_number <= 4
     // Only for tests
-    fn get_random_small_modular<T: Modular, R: CryptoRng + RngCore>(
+    fn get_random_small_modular<T: Modular, R: CryptoCoreRng>(
         mod_byte_number: u8,
         rng: &mut R,
     ) -> T {

--- a/tom256/src/arithmetic/multimult.rs
+++ b/tom256/src/arithmetic/multimult.rs
@@ -5,7 +5,7 @@ use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use std::collections::binary_heap::BinaryHeap;
 use std::fmt;
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 
 #[derive(Debug, Clone)]
 pub struct Pair<C: Curve> {
@@ -131,7 +131,7 @@ impl<C: Curve> Relation<C> {
         self.pairs.push(Pair { point, scalar })
     }
 
-    pub fn drain<R: RngCore + CryptoRng>(self, rng: &mut R, multimult: &mut MultiMult<C>) {
+    pub fn drain<R: CryptoCoreRng>(self, rng: &mut R, multimult: &mut MultiMult<C>) {
         let randomizer = Scalar::<C>::random(rng);
         for pair in self.pairs {
             multimult.insert(pair.point, pair.scalar * randomizer);

--- a/tom256/src/arithmetic/scalar.rs
+++ b/tom256/src/arithmetic/scalar.rs
@@ -1,7 +1,7 @@
 use super::modular::{mod_u256, random_mod_u256, Modular};
 use crate::curve::Curve;
+use crate::rng::CryptoCoreRng;
 use crate::U256;
-use rand_core::{CryptoRng, RngCore};
 
 use bigint::Encoding;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -52,7 +52,7 @@ impl<C: Curve> Scalar<C> {
             .collect()
     }
 
-    pub fn random<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: CryptoCoreRng>(rng: &mut R) -> Self {
         random_mod_u256::<Self, R>(rng)
     }
 }

--- a/tom256/src/lib.rs
+++ b/tom256/src/lib.rs
@@ -5,6 +5,7 @@ mod hasher;
 pub mod parse;
 pub mod pedersen;
 pub mod proofs;
+mod rng;
 
 pub use bigint::U256;
 use curve::{Secp256k1, Tom256k1};

--- a/tom256/src/pedersen.rs
+++ b/tom256/src/pedersen.rs
@@ -1,7 +1,7 @@
 use crate::arithmetic::{Point, Scalar};
 use crate::curve::{Curve, Cycle};
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -11,7 +11,7 @@ pub struct PedersenCycle<C: Curve, CC: Cycle<C>> {
 }
 
 impl<C: Curve, CC: Cycle<C>> PedersenCycle<C, CC> {
-    pub fn new<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn new<R: CryptoCoreRng>(rng: &mut R) -> Self {
         Self {
             base: PedersenGenerator::new(rng),
             cycle: PedersenGenerator::new(rng),
@@ -31,7 +31,7 @@ impl<C: Curve, CC: Cycle<C>> PedersenCycle<C, CC> {
 pub struct PedersenGenerator<C: Curve>(Point<C>);
 
 impl<C: Curve> PedersenGenerator<C> {
-    pub fn new<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn new<R: CryptoCoreRng>(rng: &mut R) -> Self {
         let random_scalar = Scalar::random(rng);
         Self(&Point::<C>::GENERATOR * random_scalar)
     }
@@ -40,7 +40,7 @@ impl<C: Curve> PedersenGenerator<C> {
         &self.0
     }
 
-    pub fn commit<R: CryptoRng + RngCore>(
+    pub fn commit<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         secret: Scalar<C>,
@@ -55,7 +55,7 @@ impl<C: Curve> PedersenGenerator<C> {
             randomness,
         }
     }
-    pub fn commit_with_generator<R: CryptoRng + RngCore>(
+    pub fn commit_with_generator<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         secret: Scalar<C>,

--- a/tom256/src/proofs/equality.rs
+++ b/tom256/src/proofs/equality.rs
@@ -4,7 +4,7 @@ use crate::curve::Curve;
 use crate::hasher::PointHasher;
 use crate::pedersen::*;
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
@@ -21,7 +21,7 @@ pub struct EqualityProof<C: Curve> {
 impl<C: Curve> EqualityProof<C> {
     const HASH_ID: &'static [u8] = b"equality-proof";
 
-    pub fn construct<R: CryptoRng + RngCore>(
+    pub fn construct<R: CryptoCoreRng>(
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,
         commitment_1: &PedersenCommitment<C>,
@@ -56,7 +56,7 @@ impl<C: Curve> EqualityProof<C> {
         }
     }
 
-    pub fn aggregate<R: CryptoRng + RngCore>(
+    pub fn aggregate<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,
@@ -90,7 +90,7 @@ impl<C: Curve> EqualityProof<C> {
     }
 
     #[cfg(test)]
-    pub fn verify<R: CryptoRng + RngCore>(
+    pub fn verify<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,

--- a/tom256/src/proofs/exp.rs
+++ b/tom256/src/proofs/exp.rs
@@ -6,8 +6,8 @@ use crate::hasher::PointHasher;
 use crate::pedersen::*;
 use crate::proofs::point_add::{PointAddCommitmentPoints, PointAddProof, PointAddSecrets};
 
+use crate::rng::CryptoCoreRng;
 use bigint::{Encoding, Integer, U256};
-use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
@@ -69,7 +69,7 @@ impl<C: Curve> ExpSecrets<C> {
         pedersen: &PedersenCycle<C, CC>,
     ) -> ExpCommitments<C, CC>
     where
-        R: CryptoRng + RngCore,
+        R: CryptoCoreRng,
         CC: Cycle<C>,
     {
         ExpCommitments {
@@ -108,7 +108,7 @@ pub struct ExpProof<C: Curve, CC: Cycle<C>> {
 impl<CC: Cycle<C>, C: Curve> ExpProof<C, CC> {
     const HASH_ID: &'static [u8] = b"exp-proof";
 
-    pub fn construct<R: CryptoRng + RngCore>(
+    pub fn construct<R: CryptoCoreRng>(
         rng: &mut R,
         base_gen: &Point<C>,
         pedersen: &PedersenCycle<C, CC>,
@@ -225,7 +225,7 @@ impl<CC: Cycle<C>, C: Curve> ExpProof<C, CC> {
         })
     }
 
-    pub fn verify<R: CryptoRng + RngCore>(
+    pub fn verify<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         base_gen: &Point<C>,
@@ -394,15 +394,11 @@ fn padded_bits(number: U256, length: usize) -> Vec<bool> {
 }
 
 // Get random number from interval [min, max]
-fn get_rand_range<R: CryptoRng + RngCore>(min: usize, max: usize, rng: &mut R) -> usize {
+fn get_rand_range<R: CryptoCoreRng>(min: usize, max: usize, rng: &mut R) -> usize {
     rng.next_u64() as usize % (max - min + 1) + min
 }
 
-fn generate_indices<R: CryptoRng + RngCore>(
-    idx_num: usize,
-    limit: usize,
-    rng: &mut R,
-) -> Vec<usize> {
+fn generate_indices<R: CryptoCoreRng>(idx_num: usize, limit: usize, rng: &mut R) -> Vec<usize> {
     let mut ret = Vec::<usize>::with_capacity(limit);
 
     for i in 0..limit {

--- a/tom256/src/proofs/membership.rs
+++ b/tom256/src/proofs/membership.rs
@@ -6,7 +6,7 @@ use crate::hasher::PointHasher;
 use crate::pedersen::*;
 use crate::U256;
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -24,7 +24,7 @@ pub struct MembershipProof<C: Curve> {
 impl<C: Curve> MembershipProof<C> {
     const HASH_ID: &'static [u8] = b"membership-proof";
 
-    pub fn construct<R: CryptoRng + RngCore>(
+    pub fn construct<R: CryptoCoreRng>(
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,
         commitment_to_key: &PedersenCommitment<C>,
@@ -159,7 +159,7 @@ impl<C: Curve> MembershipProof<C> {
         })
     }
 
-    pub fn verify<R: CryptoRng + RngCore>(
+    pub fn verify<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,

--- a/tom256/src/proofs/mod.rs
+++ b/tom256/src/proofs/mod.rs
@@ -15,7 +15,7 @@ use crate::hasher::PointHasher;
 use crate::parse::{ParsedProofInput, ParsedRing};
 use crate::pedersen::PedersenCycle;
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 use serde::{Deserialize, Serialize};
 
 // NOTE 80 is conservative but slow, 40 is faster but quite low security
@@ -45,7 +45,7 @@ pub struct ZkAttestProof<C: Curve, CC: Cycle<C>> {
 }
 
 impl<C: Curve, CC: Cycle<C>> ZkAttestProof<C, CC> {
-    pub fn construct<R: CryptoRng + RngCore>(
+    pub fn construct<R: CryptoCoreRng>(
         rng: &mut R,
         pedersen: PedersenCycle<C, CC>,
         input: ParsedProofInput<C>,
@@ -106,7 +106,7 @@ impl<C: Curve, CC: Cycle<C>> ZkAttestProof<C, CC> {
         })
     }
 
-    pub fn verify<R: CryptoRng + RngCore>(
+    pub fn verify<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         ring: &ParsedRing<CC>,

--- a/tom256/src/proofs/multiplication.rs
+++ b/tom256/src/proofs/multiplication.rs
@@ -4,7 +4,7 @@ use crate::curve::Curve;
 use crate::hasher::PointHasher;
 use crate::pedersen::*;
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
@@ -30,7 +30,7 @@ impl<C: Curve> MultiplicationProof<C> {
     const HASH_ID: &'static [u8] = b"multiplication-proof";
 
     #[allow(clippy::too_many_arguments)]
-    pub fn construct<R: CryptoRng + RngCore>(
+    pub fn construct<R: CryptoCoreRng>(
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,
         commitment_to_x: &PedersenCommitment<C>,
@@ -101,7 +101,7 @@ impl<C: Curve> MultiplicationProof<C> {
         }
     }
 
-    pub fn aggregate<R: CryptoRng + RngCore>(
+    pub fn aggregate<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,
@@ -163,7 +163,7 @@ impl<C: Curve> MultiplicationProof<C> {
     }
 
     #[cfg(test)]
-    pub fn verify<R: CryptoRng + RngCore>(
+    pub fn verify<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<C>,

--- a/tom256/src/proofs/point_add.rs
+++ b/tom256/src/proofs/point_add.rs
@@ -7,7 +7,7 @@ use crate::pedersen::*;
 use super::equality::EqualityProof;
 use super::multiplication::MultiplicationProof;
 
-use rand_core::{CryptoRng, RngCore};
+use crate::rng::CryptoCoreRng;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
@@ -31,7 +31,7 @@ impl<C: Curve> PointAddSecrets<C> {
         pedersen_generator: &PedersenGenerator<CC>,
     ) -> PointAddCommitments<CC>
     where
-        R: CryptoRng + RngCore,
+        R: CryptoCoreRng,
         CC: Cycle<C>,
     {
         PointAddCommitments {
@@ -54,7 +54,7 @@ impl<C: Curve> PointAddSecrets<C> {
         ry: PedersenCommitment<CC>,
     ) -> PointAddCommitments<CC>
     where
-        R: CryptoRng + RngCore,
+        R: CryptoCoreRng,
         CC: Cycle<C>,
     {
         PointAddCommitments {
@@ -146,7 +146,7 @@ pub struct PointAddProof<CC: Cycle<C>, C: Curve> {
 }
 
 impl<CC: Cycle<C>, C: Curve> PointAddProof<CC, C> {
-    pub fn construct<R: CryptoRng + RngCore>(
+    pub fn construct<R: CryptoCoreRng>(
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<CC>,
         commitments: &PointAddCommitments<CC>,
@@ -243,7 +243,7 @@ impl<CC: Cycle<C>, C: Curve> PointAddProof<CC, C> {
         }
     }
 
-    pub fn aggregate<R: CryptoRng + RngCore>(
+    pub fn aggregate<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<CC>,
@@ -311,7 +311,7 @@ impl<CC: Cycle<C>, C: Curve> PointAddProof<CC, C> {
     }
 
     #[cfg(test)]
-    pub fn verify<R: CryptoRng + RngCore>(
+    pub fn verify<R: CryptoCoreRng>(
         &self,
         rng: &mut R,
         pedersen_generator: &PedersenGenerator<CC>,

--- a/tom256/src/rng.rs
+++ b/tom256/src/rng.rs
@@ -1,5 +1,4 @@
-use rand::rngs::{OsRng, StdRng};
-use rand_core::{CryptoRng, RngCore, SeedableRng};
+use rand_core::{CryptoRng, OsRng, RngCore};
 
 pub trait RngDefault {
     fn default() -> Self;
@@ -13,11 +12,18 @@ impl RngDefault for OsRng {
     }
 }
 
+impl CryptoCoreRng for OsRng {}
+
+#[cfg(test)]
+use rand::rngs::StdRng;
+#[cfg(test)]
+use rand_core::SeedableRng;
+
+#[cfg(test)]
 impl RngDefault for StdRng {
     fn default() -> Self {
         StdRng::from_entropy()
     }
 }
-
-impl CryptoCoreRng for OsRng {}
+#[cfg(test)]
 impl CryptoCoreRng for StdRng {}

--- a/tom256/src/rng.rs
+++ b/tom256/src/rng.rs
@@ -1,0 +1,23 @@
+use rand::rngs::{OsRng, StdRng};
+use rand_core::{CryptoRng, RngCore, SeedableRng};
+
+pub trait RngDefault {
+    fn default() -> Self;
+}
+
+pub trait CryptoCoreRng: RngCore + CryptoRng + RngDefault {}
+
+impl RngDefault for OsRng {
+    fn default() -> Self {
+        OsRng
+    }
+}
+
+impl RngDefault for StdRng {
+    fn default() -> Self {
+        StdRng::from_entropy()
+    }
+}
+
+impl CryptoCoreRng for OsRng {}
+impl CryptoCoreRng for StdRng {}


### PR DESCRIPTION
# Description

Aims to resolve #4. Added trait `CryptoCoreRng` which includes `CryptoRng` and `RngCore` used currently. Also includes a new trait `RngDefault` which can be useful for parallelization when individual Rng instances are required in all threads.