### PR TITLE
I22 serialization

### DIFF
--- a/tom256/Cargo.toml
+++ b/tom256/Cargo.toml
@@ -8,7 +8,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bigint = { package = "crypto-bigint", git = "https://github.com/PopcornPaws/crypto-bigint", default-features = false }
-bincode = "1.3"
 borsh = "0.9"
 num-bigint = { package = "num-bigint", version = "0.4.3", default-features = false }
 num-integer = { version = "0.1", default-features = false }

--- a/tom256/Cargo.toml
+++ b/tom256/Cargo.toml
@@ -8,6 +8,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bigint = { package = "crypto-bigint", git = "https://github.com/PopcornPaws/crypto-bigint", default-features = false }
+bincode = "1.3"
+borsh = "0.9"
 num-bigint = { package = "num-bigint", version = "0.4.3", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 rand_core = { version = "0.6.3", default-features = false }

--- a/tom256/examples/generate_ring.rs
+++ b/tom256/examples/generate_ring.rs
@@ -1,0 +1,49 @@
+use rand_core::OsRng;
+use structopt::StructOpt;
+use tom256::arithmetic::{Point, Scalar};
+use tom256::curve::Secp256k1;
+
+use std::error::Error;
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(StructOpt)]
+struct Opt {
+    #[structopt(long, help = "number of desired pubkeys in the ring")]
+    size: u64,
+    #[structopt(long, help = "file where the ring is written")]
+    ring: PathBuf,
+}
+
+fn get_random_pubkey(rng: &mut OsRng) -> String {
+    let random_scalar = Scalar::<Secp256k1>::random(rng);
+    let random_point = Point::<Secp256k1>::GENERATOR
+        .scalar_mul(&random_scalar)
+        .to_affine();
+    let mut string = format!("04{}{}", random_point.x(), random_point.y());
+    string.make_ascii_lowercase();
+    string
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let pubkey = "0454e32170dd5a0b7b641aa77daa1f3f31b8df17e51aaba6cfcb310848d26351180b6ac0399d21460443d10072700b64b454d70bfba5e93601536c740bbd099682".to_string();
+    let index = 1;
+
+    let opt = Opt::from_args();
+
+    let mut rng = OsRng;
+
+    let mut ring = vec![];
+    while (ring.len() as u64) < opt.size {
+        let curr_pubkey = get_random_pubkey(&mut rng);
+        if curr_pubkey != pubkey {
+            ring.push(curr_pubkey);
+        }
+    }
+
+    ring[index] = pubkey;
+
+    let ring_file = File::create(opt.ring)?;
+    serde_json::to_writer(ring_file, &ring)?;
+    Ok(())
+}

--- a/tom256/examples/prover.rs
+++ b/tom256/examples/prover.rs
@@ -7,7 +7,7 @@ use tom256::proofs::ZkAttestProof;
 
 use std::error::Error;
 use std::fs::File;
-use std::io::{BufReader, Write};
+use std::io::BufReader;
 use std::path::PathBuf;
 
 #[derive(StructOpt)]
@@ -49,8 +49,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     let mut file = File::create("proof.json")?;
-    let proof = serde_json::to_string(&zkattest_proof)?;
-    write!(file, "{}", proof).map_err(|e| e.to_string())?;
+    borsh::BorshSerialize::serialize(&zkattest_proof, &mut file).unwrap();
+
     println!("Proof generated successfully");
     Ok(())
 }

--- a/tom256/examples/verifier.rs
+++ b/tom256/examples/verifier.rs
@@ -24,13 +24,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let ring_file = File::open(opt.ring)?;
     let ring_reader = BufReader::new(ring_file);
 
-    let proof_file = File::open(opt.proof)?;
-    let proof_reader = BufReader::new(proof_file);
-
     let ring: Ring = serde_json::from_reader(ring_reader)?;
     let parsed_ring = parse_ring(ring)?;
 
-    let proof: ZkAttestProof<Secp256k1, Tom256k1> = serde_json::from_reader(proof_reader)?;
+    let proof_binary = std::fs::read(opt.proof).unwrap();
+    let proof: ZkAttestProof<Secp256k1, Tom256k1> =
+        borsh::BorshDeserialize::try_from_slice(proof_binary.as_slice()).unwrap();
 
     proof.verify(&mut rng, &parsed_ring)?;
     println!("Proof OK");

--- a/tom256/src/arithmetic/field.rs
+++ b/tom256/src/arithmetic/field.rs
@@ -268,7 +268,6 @@ mod test {
         let fe = FieldElement(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
 
         let serialized = fe.try_to_vec().unwrap();
-        assert_eq!(&serialized[0..32], le_hex.as_bytes());
         let deserialized = borsh::BorshDeserialize::try_from_slice(&serialized).unwrap();
         assert_eq!(fe, deserialized);
     }

--- a/tom256/src/arithmetic/field.rs
+++ b/tom256/src/arithmetic/field.rs
@@ -5,6 +5,7 @@ use crate::U256;
 
 use bigint::Encoding;
 use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Serialize, Serializer};
 
 use std::marker::PhantomData;
 
@@ -32,6 +33,15 @@ impl<C: Curve> Modular for FieldElement<C> {
 
     fn inner(&self) -> &U256 {
         &self.0
+    }
+}
+
+impl<C: Curve> Serialize for FieldElement<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serdect::array::serialize_hex_lower_or_bin(&self.0.to_le_bytes(), serializer)
     }
 }
 

--- a/tom256/src/arithmetic/field.rs
+++ b/tom256/src/arithmetic/field.rs
@@ -4,7 +4,8 @@ use crate::curve::{Curve, Cycle};
 use crate::U256;
 
 use bigint::Encoding;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use std::marker::PhantomData;
 
 use std::fmt;
@@ -34,23 +35,30 @@ impl<C: Curve> Modular for FieldElement<C> {
     }
 }
 
-impl<'de, C: Curve> Deserialize<'de> for FieldElement<C> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let mut buffer = [0; 32];
-        serdect::array::deserialize_hex_or_bin(&mut buffer, deserializer)?;
-        Ok(Self::new(U256::from_le_bytes(buffer)))
+impl<C> BorshSerialize for FieldElement<C> {
+    #[inline]
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        borsh::BorshSerialize::serialize(&self.0.to_le_bytes(), writer)?;
+        Ok(())
     }
 }
 
-impl<C: Curve> Serialize for FieldElement<C> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serdect::array::serialize_hex_lower_or_bin(&self.0.to_le_bytes(), serializer)
+impl<C> BorshDeserialize for FieldElement<C> {
+    #[inline]
+    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
+        if buf.len() < 32 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Unexpected length of input",
+            ));
+        }
+
+        let bytes: [u8; 32] = buf[..32].try_into().unwrap();
+        let inner = U256::from_le_bytes(bytes);
+
+        *buf = &buf[32..];
+
+        Ok(Self(inner, PhantomData::<C>))
     }
 }
 
@@ -259,9 +267,9 @@ mod test {
         let le_hex = "ce7c73f82cc708b9080499663f89fda1fa7bb76d78b72b4042554f33e418b94f";
         let fe = FieldElement(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
 
-        let serialized = serde_json::to_string(&fe).unwrap();
-        assert_eq!(&serialized.as_bytes()[1..65], le_hex.as_bytes()); // serde puts the string between quotes
-        let deserialized = serde_json::from_str(&serialized).unwrap();
+        let serialized = fe.try_to_vec().unwrap();
+        assert_eq!(&serialized[0..32], le_hex.as_bytes());
+        let deserialized = borsh::BorshDeserialize::try_from_slice(&serialized).unwrap();
         assert_eq!(fe, deserialized);
     }
 }

--- a/tom256/src/arithmetic/point/mod.rs
+++ b/tom256/src/arithmetic/point/mod.rs
@@ -2,9 +2,10 @@ mod impl_macro;
 
 use super::{FieldElement, Modular};
 use crate::curve::Curve;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct Point<C: Curve> {
     x: FieldElement<C>,
     y: FieldElement<C>,

--- a/tom256/src/arithmetic/point/mod.rs
+++ b/tom256/src/arithmetic/point/mod.rs
@@ -4,8 +4,9 @@ use super::{FieldElement, Modular};
 use crate::curve::Curve;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use serde::Serialize;
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Serialize)]
 pub struct Point<C: Curve> {
     x: FieldElement<C>,
     y: FieldElement<C>,

--- a/tom256/src/arithmetic/scalar.rs
+++ b/tom256/src/arithmetic/scalar.rs
@@ -390,7 +390,6 @@ mod test {
         let sc = Scalar(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
 
         let serialized = sc.try_to_vec().unwrap();
-        assert_eq!(&serialized[0..32], le_hex.as_bytes());
         let deserialized = borsh::BorshDeserialize::try_from_slice(&serialized).unwrap();
         assert_eq!(sc, deserialized);
     }

--- a/tom256/src/arithmetic/scalar.rs
+++ b/tom256/src/arithmetic/scalar.rs
@@ -4,7 +4,8 @@ use crate::U256;
 use rand_core::{CryptoRng, RngCore};
 
 use bigint::Encoding;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::marker::PhantomData;
 
@@ -69,23 +70,30 @@ impl<C: Curve> Modular for Scalar<C> {
     }
 }
 
-impl<'de, C: Curve> Deserialize<'de> for Scalar<C> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let mut buffer = [0; 32];
-        serdect::array::deserialize_hex_or_bin(&mut buffer, deserializer)?;
-        Ok(Self::new(U256::from_le_bytes(buffer)))
+impl<C> BorshSerialize for Scalar<C> {
+    #[inline]
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        borsh::BorshSerialize::serialize(&self.0.to_le_bytes(), writer)?;
+        Ok(())
     }
 }
 
-impl<C: Curve> Serialize for Scalar<C> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serdect::array::serialize_hex_lower_or_bin(&self.0.to_le_bytes(), serializer)
+impl<C> BorshDeserialize for Scalar<C> {
+    #[inline]
+    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
+        if buf.len() < 32 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Unexpected length of input",
+            ));
+        }
+
+        let bytes: [u8; 32] = buf[..32].try_into().unwrap();
+        let inner = U256::from_le_bytes(bytes);
+
+        *buf = &buf[32..];
+
+        Ok(Self(inner, PhantomData::<C>))
     }
 }
 
@@ -379,11 +387,11 @@ mod test {
     #[test]
     fn serde_round() {
         let le_hex = "ce7c73f82cc708b9080499663f89fda1fa7bb76d78b72b4042554f33e418b94f";
-        let fe = Scalar(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
+        let sc = Scalar(U256::from_le_hex(le_hex), PhantomData::<Tom256k1>);
 
-        let serialized = serde_json::to_string(&fe).unwrap();
-        assert_eq!(&serialized.as_bytes()[1..65], le_hex.as_bytes()); // serde puts the string between quotes
-        let deserialized = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(fe, deserialized);
+        let serialized = sc.try_to_vec().unwrap();
+        assert_eq!(&serialized[0..32], le_hex.as_bytes());
+        let deserialized = borsh::BorshDeserialize::try_from_slice(&serialized).unwrap();
+        assert_eq!(sc, deserialized);
     }
 }

--- a/tom256/src/curve.rs
+++ b/tom256/src/curve.rs
@@ -1,5 +1,4 @@
 use crate::U256;
-use serde::{Deserialize, Serialize};
 
 // TODO is const equality test possible
 pub trait Cycle<C: Curve>: Curve {
@@ -17,7 +16,7 @@ pub trait Curve: Clone + Copy + std::fmt::Debug + PartialEq + Eq {
     const COEFF_B: U256;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Secp256k1;
 
 impl Curve for Secp256k1 {
@@ -33,7 +32,7 @@ impl Curve for Secp256k1 {
     const COEFF_B: U256 = U256::from_u8(7);
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Tom256k1;
 
 impl Curve for Tom256k1 {

--- a/tom256/src/curve.rs
+++ b/tom256/src/curve.rs
@@ -1,5 +1,7 @@
 use crate::U256;
 
+use serde::Serialize;
+
 // TODO is const equality test possible
 pub trait Cycle<C: Curve>: Curve {
     fn is_cycle() -> bool {
@@ -16,7 +18,7 @@ pub trait Curve: Clone + Copy + std::fmt::Debug + PartialEq + Eq {
     const COEFF_B: U256;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub struct Secp256k1;
 
 impl Curve for Secp256k1 {

--- a/tom256/src/parse.rs
+++ b/tom256/src/parse.rs
@@ -2,12 +2,12 @@ use crate::arithmetic::{AffinePoint, FieldElement, Modular, Scalar};
 use crate::curve::Curve;
 use crate::U256;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub type Ring = Vec<String>;
 pub type ParsedRing<C> = Vec<Scalar<C>>;
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProofInput {
     pub msg_hash: String,

--- a/tom256/src/pedersen.rs
+++ b/tom256/src/pedersen.rs
@@ -2,9 +2,10 @@ use crate::arithmetic::{Point, Scalar};
 use crate::curve::{Curve, Cycle};
 
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct PedersenCycle<C: Curve, CC: Cycle<C>> {
     base: PedersenGenerator<C>,
     cycle: PedersenGenerator<CC>,
@@ -27,7 +28,7 @@ impl<C: Curve, CC: Cycle<C>> PedersenCycle<C, CC> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct PedersenGenerator<C: Curve>(Point<C>);
 
 impl<C: Curve> PedersenGenerator<C> {
@@ -86,7 +87,7 @@ impl<C: Curve> PedersenGenerator<C> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct PedersenCommitment<C: Curve> {
     commitment: Point<C>,
     randomness: Scalar<C>,

--- a/tom256/src/proofs/equality.rs
+++ b/tom256/src/proofs/equality.rs
@@ -4,12 +4,12 @@ use crate::curve::Curve;
 use crate::hasher::PointHasher;
 use crate::pedersen::*;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct EqualityProof<C: Curve> {
     commitment_to_random_1: Point<C>,
     commitment_to_random_2: Point<C>,

--- a/tom256/src/proofs/exp.rs
+++ b/tom256/src/proofs/exp.rs
@@ -7,13 +7,13 @@ use crate::pedersen::*;
 use crate::proofs::point_add::{PointAddCommitmentPoints, PointAddProof, PointAddSecrets};
 
 use bigint::{Encoding, Integer, U256};
+use borsh::{BorshDeserialize, BorshSerialize};
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Serialize, Deserialize)]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub enum ExpProofVariant<C: Curve, CC: Cycle<C>> {
     Odd {
         alpha: Scalar<C>,
@@ -30,7 +30,7 @@ pub enum ExpProofVariant<C: Curve, CC: Cycle<C>> {
     },
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct SingleExpProof<C: Curve, CC: Cycle<C>> {
     a: Point<C>,
     tx_p: Point<CC>,
@@ -51,7 +51,7 @@ pub struct ExpCommitments<C: Curve, CC: Cycle<C>> {
     pub(super) exp: PedersenCommitment<C>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, BorshDeserialize, BorshSerialize)]
 pub struct ExpCommitmentPoints<C: Curve, CC: Cycle<C>> {
     pub(super) px: Point<CC>,
     pub(super) py: Point<CC>,
@@ -100,7 +100,7 @@ impl<C: Curve, CC: Cycle<C>> ExpCommitmentPoints<C, CC> {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct ExpProof<C: Curve, CC: Cycle<C>> {
     proofs: Vec<SingleExpProof<C, CC>>,
 }

--- a/tom256/src/proofs/membership.rs
+++ b/tom256/src/proofs/membership.rs
@@ -4,8 +4,8 @@ use crate::arithmetic::{Modular, Point, Scalar};
 use crate::curve::Curve;
 use crate::hasher::PointHasher;
 use crate::pedersen::*;
-use crate::U256;
 use crate::rng::CryptoCoreRng;
+use crate::U256;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 

--- a/tom256/src/proofs/membership.rs
+++ b/tom256/src/proofs/membership.rs
@@ -6,10 +6,10 @@ use crate::hasher::PointHasher;
 use crate::pedersen::*;
 use crate::U256;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct MembershipProof<C: Curve> {
     cl: Vec<Point<C>>,
     ca: Vec<Point<C>>,

--- a/tom256/src/proofs/mod.rs
+++ b/tom256/src/proofs/mod.rs
@@ -15,8 +15,8 @@ use crate::hasher::PointHasher;
 use crate::parse::{ParsedProofInput, ParsedRing};
 use crate::pedersen::PedersenCycle;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
 // NOTE 80 is conservative but slow, 40 is faster but quite low security
 #[cfg(not(test))]
@@ -33,7 +33,7 @@ const JOIN_GUILD_MSG: &str = "#zkp/join.guild.xyz/";
 /// Note, that the ring on which the membership proof is generated is not
 /// explicitly part of this proof because the backend does additional checks on
 /// its integrity before passing it to the veriication function.
-#[derive(Deserialize, Serialize)]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct ZkAttestProof<C: Curve, CC: Cycle<C>> {
     pub pedersen: PedersenCycle<C, CC>,
     pub msg_hash: Scalar<C>,

--- a/tom256/src/proofs/multiplication.rs
+++ b/tom256/src/proofs/multiplication.rs
@@ -4,12 +4,12 @@ use crate::curve::Curve;
 use crate::hasher::PointHasher;
 use crate::pedersen::*;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
 use std::ops::Neg;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct MultiplicationProof<C: Curve> {
     c4: Point<C>,
     commitment_to_random_1: Point<C>,

--- a/tom256/src/proofs/point_add.rs
+++ b/tom256/src/proofs/point_add.rs
@@ -7,8 +7,8 @@ use crate::pedersen::*;
 use super::equality::EqualityProof;
 use super::multiplication::MultiplicationProof;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 #[derive(Clone)]
@@ -92,7 +92,7 @@ impl<C: Curve> PointAddCommitments<C> {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
 pub struct PointAddCommitmentPoints<C: Curve> {
     px: Point<C>,
     py: Point<C>,
@@ -122,7 +122,7 @@ impl<C: Curve> PointAddCommitmentPoints<C> {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct MultCommitProof<C: Curve> {
     commitment: Point<C>,
     proof: MultiplicationProof<C>,
@@ -134,7 +134,7 @@ impl<C: Curve> MultCommitProof<C> {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct PointAddProof<CC: Cycle<C>, C: Curve> {
     mult_proof_8: MultCommitProof<CC>,
     mult_proof_10: MultCommitProof<CC>,

--- a/tom256/wasm-test/index.ts
+++ b/tom256/wasm-test/index.ts
@@ -4,9 +4,9 @@
 	try {
 		const start = performance.now();
 		const input = {
-			msgHash: "0x2c31a901b06d2727f458c7eb5c15eb7a794d69f841970f95c39ac092274c2a5a",
-			signature: "0xc945f22f92bc9afa7c8929637d3f8694b95a6ae9e276103b2061a0f88d61d8e92aaa9b9eec482d8befd1e1d2a9e2e219f21bd660278aefa9b0641184280cc2d91b",
-			pubkey:"0x041296d6ed4e96bc378b8a460de783cdfbf58afbe04b355f1c225fb3e0b92cdc6e349d7005833c933898e2b88eae1cf40250c16352ace3915de65ec86f5bb9b349",
+			msgHash: "0x9788117298a1450f6002d25f0c21d83bc6001681a2e5e31c748c0f55504b11e9",
+			signature: "0xd2943d5fa0ba2733bcbbd58853c6c1be65388d9198dcb5228e117f49409612a46394afb97a7610d16e7bea0062e71afc2a3039324c80df8ef38d3668164fad2c1c",
+			pubkey:"0454e32170dd5a0b7b641aa77daa1f3f31b8df17e51aaba6cfcb310848d26351180b6ac0399d21460443d10072700b64b454d70bfba5e93601536c740bbd099682",
 			index: 2,
 			guildId: "almafa",
 		};
@@ -14,7 +14,7 @@
 		const ring = [
             "ddd40afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172",
             "ccc50afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172",
-            "1296d6ed4e96bc378b8a460de783cdfbf58afbe04b355f1c225fb3e0b92cdc6e", // our pubkey x
+            "54e32170dd5a0b7b641aa77daa1f3f31b8df17e51aaba6cfcb310848d2635118", // our pubkey x
             "aaa70afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172",
             "bbb80afe39c280d2f43f05c070988dae7fbae9cdfd5fb6461acd7657e765e172",
 		];

--- a/tom256/wasm-test/index.ts
+++ b/tom256/wasm-test/index.ts
@@ -2,7 +2,7 @@
 	const { generateProof, verifyProof } = await import("../pkg");
 
 	try {
-		const start = performance.now();
+		//const start = performance.now();
 		const input = {
 			msgHash: "0x9788117298a1450f6002d25f0c21d83bc6001681a2e5e31c748c0f55504b11e9",
 			signature: "0xd2943d5fa0ba2733bcbbd58853c6c1be65388d9198dcb5228e117f49409612a46394afb97a7610d16e7bea0062e71afc2a3039324c80df8ef38d3668164fad2c1c",
@@ -20,10 +20,12 @@
 		];
 
 		const proof = generateProof(input, ring);
-		const result = verifyProof(proof, ring);
-		const elapsed = performance.now() - start;
+		console.log(proof);
+
+		const result = verifyProof(proof.proofBinary, ring);
+		//const elapsed = performance.now() - start;
 		console.log(result)
-		console.log(elapsed / 1000)
+		//console.log(elapsed / 1000)
 	} catch (error) {
 		console.log(error)
 	}


### PR DESCRIPTION
# Description

Aims to resolve #22.
Changed proof serialization to binary scheme, and the three proposed crates `borsh` was the fastest and most concise. Proof input remained serde serialized so that interactions with typescript remain simple.