### PR TITLE
I46 poly eval

### DIFF
--- a/agora-interpolate/Cargo.toml
+++ b/agora-interpolate/Cargo.toml
@@ -8,7 +8,11 @@ k256-scalar = ["k256"]
 bls-scalar = ["bls"]
 
 [dependencies]
-bls = { package = "bls12_381", version = "0.6.0", optional = true}
+bls = { package = "bls12_381", version = "0.6.0", optional = true }
 k256 = { version = "0.11", optional = true }
 subtle = "2.4.1"
 thiserror = "1.0"
+
+[dev-dependencies]
+bls = { package = "bls12_381", version = "0.6.0" }
+k256 = { version = "0.11" }

--- a/agora-interpolate/src/bls_scalar.rs
+++ b/agora-interpolate/src/bls_scalar.rs
@@ -21,4 +21,4 @@ impl Interpolate for Scalar {
 }
 
 #[cfg(test)]
-crate::macros::test_interpolate!(bls::Scalar);
+crate::macros::test_polynomial!(bls::Scalar);

--- a/agora-interpolate/src/k256_scalar.rs
+++ b/agora-interpolate/src/k256_scalar.rs
@@ -21,4 +21,4 @@ impl Interpolate for Scalar {
 }
 
 #[cfg(test)]
-crate::macros::test_interpolate!(k256::Scalar);
+crate::macros::test_polynomial!(k256::Scalar);

--- a/agora-interpolate/src/lib.rs
+++ b/agora-interpolate/src/lib.rs
@@ -15,7 +15,7 @@ pub use polynomial::Polynomial;
 use subtle::CtOption;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum InterpolationError {
     #[error("unequal slice lengths: {0} and {1}")]
     InvalidInputLengths(usize, usize),

--- a/agora-interpolate/src/lib.rs
+++ b/agora-interpolate/src/lib.rs
@@ -1,24 +1,28 @@
-#![deny(warnings)]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
 #![deny(clippy::all)]
 #![deny(clippy::dbg_macro)]
 
 #[cfg(test)]
 mod macros;
 
-#[cfg(feature = "bls-scalar")]
+#[cfg(any(test, feature = "bls-scalar"))]
 mod bls_scalar;
-#[cfg(feature = "k256-scalar")]
+#[cfg(any(test, feature = "k256-scalar"))]
 mod k256_scalar;
+mod polynomial;
+
+pub use polynomial::Polynomial;
 
 use subtle::CtOption;
 use thiserror::Error;
 
-use std::ops::{AddAssign, Mul, MulAssign, Neg, SubAssign};
-
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum InterpolationError {
     #[error("unequal slice lengths: {0} and {1}")]
     InvalidInputLengths(usize, usize),
+    #[error("not enough samples: {0}, expected > {1}")]
+    NotEnoughSamples(usize, usize),
     #[error("attempted to invert a zero scalar")]
     TriedToInvertZero,
 }
@@ -36,48 +40,4 @@ pub trait Interpolate {
     fn inverse(&self) -> CtOption<Self>
     where
         Self: Sized;
-}
-
-pub fn interpolate<T>(x: &[T], y: &[T]) -> Result<Vec<T>, InterpolationError>
-where
-    T: Interpolate + Copy + Mul<Output = T> + Neg<Output = T> + AddAssign + SubAssign + MulAssign,
-{
-    if x.len() != y.len() {
-        return Err(InterpolationError::InvalidInputLengths(x.len(), y.len()));
-    }
-
-    let n = x.len();
-
-    let mut s = vec![T::zero(); n];
-    let mut coeffs = vec![T::zero(); n];
-
-    s.push(T::one());
-    s[n - 1] = -x[0];
-
-    for (i, &x_elem) in x.iter().enumerate().skip(1) {
-        for j in n - 1 - i..n - 1 {
-            let aux = x_elem * s[j + 1];
-            s[j] -= aux;
-        }
-        s[n - 1] -= x_elem;
-    }
-
-    for i in 0..n {
-        let mut phi = T::zero();
-        for j in (1..=n).rev() {
-            phi *= x[i];
-            phi += T::from_u64(j as u64) * s[j];
-        }
-        let maybe_ff: Option<T> = <T as Interpolate>::inverse(&phi).into();
-        let ff = maybe_ff.ok_or(InterpolationError::TriedToInvertZero)?;
-        let mut b = T::one();
-        for j in (0..n).rev() {
-            let aux = b * ff * y[i];
-            coeffs[j] += aux;
-            b *= x[i];
-            b += s[j];
-        }
-    }
-
-    Ok(coeffs)
 }

--- a/agora-interpolate/src/lib.rs
+++ b/agora-interpolate/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
 #![deny(clippy::all)]
 #![deny(clippy::dbg_macro)]
 
@@ -21,8 +19,6 @@ use thiserror::Error;
 pub enum InterpolationError {
     #[error("unequal slice lengths: {0} and {1}")]
     InvalidInputLengths(usize, usize),
-    #[error("not enough samples: {0}, expected > {1}")]
-    NotEnoughSamples(usize, usize),
     #[error("attempted to invert a zero scalar")]
     TriedToInvertZero,
 }

--- a/agora-interpolate/src/macros.rs
+++ b/agora-interpolate/src/macros.rs
@@ -6,10 +6,6 @@ macro_rules! test_polynomial {
             use std::ops::Neg;
 
             type TestScalar = $t;
-            type Poly0 = Polynomial<0, TestScalar>;
-            type Poly1 = Polynomial<1, TestScalar>;
-            type Poly2 = Polynomial<2, TestScalar>;
-            type Poly4 = Polynomial<4, TestScalar>;
 
             #[test]
             fn interpolate_and_evaluate() {
@@ -17,21 +13,14 @@ macro_rules! test_polynomial {
                 let x = vec![<TestScalar as Interpolate>::from_u64(3_u64); 3];
                 let y = vec![<TestScalar as Interpolate>::from_u64(5_u64); 4];
                 assert_eq!(
-                    Poly2::interpolate(&x, &y),
+                    Polynomial::interpolate(&x, &y),
                     Err(InterpolationError::InvalidInputLengths(3, 4))
-                );
-
-                let x = vec![<TestScalar as Interpolate>::from_u64(3_u64); 4];
-                let y = vec![<TestScalar as Interpolate>::from_u64(5_u64); 4];
-                assert_eq!(
-                    Poly4::interpolate(&x, &y),
-                    Err(InterpolationError::NotEnoughSamples(4, 5))
                 );
 
                 // constant polynomial (y = 53)
                 let x = vec![<TestScalar as Interpolate>::from_u64(3_u64); 1];
                 let y = vec![<TestScalar as Interpolate>::from_u64(53_u64); 1];
-                let poly = Poly0::interpolate(&x, &y).unwrap();
+                let poly = Polynomial::interpolate(&x, &y).unwrap();
                 assert_eq!(
                     poly.coeffs()[0],
                     <TestScalar as Interpolate>::from_u64(53_u64)
@@ -53,7 +42,7 @@ macro_rules! test_polynomial {
                 ];
 
                 let y = x.clone();
-                let poly = Poly1::interpolate(&x, &y).unwrap();
+                let poly = Polynomial::interpolate(&x, &y).unwrap();
                 assert_eq!(poly.coeffs()[0], <TestScalar as Interpolate>::zero()); // c_0
                 assert_eq!(poly.coeffs()[1], <TestScalar as Interpolate>::one()); // c_1
 
@@ -66,7 +55,7 @@ macro_rules! test_polynomial {
                     <TestScalar as Interpolate>::from_u64(51_u64),
                     <TestScalar as Interpolate>::from_u64(83_u64),
                 ];
-                let poly = Poly1::interpolate(&x, &y).unwrap();
+                let poly = Polynomial::interpolate(&x, &y).unwrap();
                 assert_eq!(
                     poly.coeffs()[0],
                     <TestScalar as Interpolate>::from_u64(13_u64).neg()
@@ -101,7 +90,7 @@ macro_rules! test_polynomial {
                     <TestScalar as Interpolate>::from_u64(724_u64),
                     <TestScalar as Interpolate>::from_u64(1430_u64),
                 ];
-                let poly = Poly4::interpolate(&x, &y).unwrap();
+                let poly = Polynomial::interpolate(&x, &y).unwrap();
                 assert_eq!(
                     poly.coeffs()[0],
                     <TestScalar as Interpolate>::from_u64(14_u64)

--- a/agora-interpolate/src/polynomial.rs
+++ b/agora-interpolate/src/polynomial.rs
@@ -1,0 +1,86 @@
+use crate::{Interpolate, InterpolationError};
+use std::ops::{AddAssign, Mul, MulAssign, Neg, SubAssign};
+
+/// An `N`th order polynomial with `N + 1` coefficients.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Polynomial<const N: usize, T>
+where
+    [(); N + 1]:,
+{
+    coeffs: [T; N + 1],
+}
+
+impl<const N: usize, T> Polynomial<N, T>
+where
+    [(); N + 1]:,
+{
+    pub fn new(coeffs: [T; N + 1]) -> Self {
+        Self { coeffs }
+    }
+
+    pub fn coeffs(&self) -> &[T; N + 1] {
+        &self.coeffs
+    }
+}
+
+impl<const N: usize, T> Polynomial<N, T>
+where
+    T: Interpolate + Copy + Mul<Output = T> + Neg<Output = T> + AddAssign + SubAssign + MulAssign,
+    [(); N + 1]:,
+{
+    pub fn interpolate(x: &[T], y: &[T]) -> Result<Self, InterpolationError> {
+        if x.len() != y.len() {
+            return Err(InterpolationError::InvalidInputLengths(x.len(), y.len()));
+        } else if x.len() < N + 1 {
+            return Err(InterpolationError::NotEnoughSamples(x.len(), N + 1));
+        }
+
+        let n = x.len();
+        let mut s = vec![T::zero(); n];
+        let mut coeffs_vec = vec![T::zero(); n];
+
+        s.push(T::one());
+        s[n - 1] = -x[0];
+
+        for (i, &x_elem) in x.iter().enumerate().skip(1) {
+            for j in n - 1 - i..n - 1 {
+                let aux = x_elem * s[j + 1];
+                s[j] -= aux;
+            }
+            s[n - 1] -= x_elem;
+        }
+
+        for i in 0..n {
+            let mut phi = T::zero();
+            for j in (1..=n).rev() {
+                phi *= x[i];
+                phi += T::from_u64(j as u64) * s[j];
+            }
+            let maybe_ff: Option<T> = <T as Interpolate>::inverse(&phi).into();
+            let ff = maybe_ff.ok_or(InterpolationError::TriedToInvertZero)?;
+            let mut b = T::one();
+            for j in (0..n).rev() {
+                let aux = b * ff * y[i];
+                coeffs_vec[j] += aux;
+                b *= x[i];
+                b += s[j];
+            }
+        }
+
+        // NOTE if x.len() > N then coeffs_vec[N + 1..]
+        // will contain all zeros because we have
+        // more samples than coefficients in the polynomial
+        let mut coeffs = [T::zero(); N + 1];
+        coeffs.copy_from_slice(&coeffs_vec[0..N + 1]);
+        Ok(Self { coeffs })
+    }
+
+    pub fn evaluate(&self, at: T) -> T {
+        let mut ret = T::zero();
+        for coeff in self.coeffs.iter().rev() {
+            ret *= at;
+            ret += *coeff;
+        }
+        ret
+    }
+}

--- a/agora-interpolate/src/polynomial.rs
+++ b/agora-interpolate/src/polynomial.rs
@@ -1,7 +1,7 @@
 use crate::{Interpolate, InterpolationError};
 use std::ops::{AddAssign, Mul, MulAssign, Neg, SubAssign};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Polynomial<T> {
     coeffs: Vec<T>,
 }

--- a/agora-zkp-ecdsa/src/proofs/membership.rs
+++ b/agora-zkp-ecdsa/src/proofs/membership.rs
@@ -118,10 +118,10 @@ impl<C: Curve> MembershipProof<C> {
         }
 
         let poly = Polynomial::interpolate(&omegas, &poly_vals).map_err(|e| e.to_string())?;
-        for i in 0..n {
+        for (coeff, &rho) in poly.into_coeffs().into_iter().zip(&rho_vec) {
             cd.push(
                 pedersen_generator
-                    .commit_with_randomness(poly.coeffs()[i], rho_vec[i])
+                    .commit_with_randomness(coeff, rho)
                     .into_commitment(),
             );
         }

--- a/agora-zkp-ecdsa/src/proofs/membership.rs
+++ b/agora-zkp-ecdsa/src/proofs/membership.rs
@@ -7,7 +7,7 @@ use crate::pedersen::*;
 use crate::rng::CryptoCoreRng;
 use crate::U256;
 
-use agora_interpolate::interpolate;
+use agora_interpolate::Polynomial;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
@@ -117,11 +117,11 @@ impl<C: Curve> MembershipProof<C> {
             poly_vals.push(poly_val);
         }
 
-        let coeffs = interpolate(&omegas, &poly_vals).map_err(|e| e.to_string())?;
+        let poly = Polynomial::interpolate(&omegas, &poly_vals).map_err(|e| e.to_string())?;
         for i in 0..n {
             cd.push(
                 pedersen_generator
-                    .commit_with_randomness(coeffs[i], rho_vec[i])
+                    .commit_with_randomness(poly.coeffs()[i], rho_vec[i])
                     .into_commitment(),
             );
         }

--- a/agora-zkp-triptych/src/signature.rs
+++ b/agora-zkp-triptych/src/signature.rs
@@ -1,5 +1,5 @@
 use crate::ring::*;
-use agora_interpolate::interpolate;
+use agora_interpolate::Polynomial;
 use k256::elliptic_curve::group::GroupEncoding;
 use k256::elliptic_curve::ops::Reduce;
 use k256::elliptic_curve::{Field, PrimeField};
@@ -349,8 +349,8 @@ fn get_coeffs(
             }
         }
 
-        let coeffs = interpolate(omegas, &evals).map_err(|e| e.to_string())?;
-        coeff_vecs.push(coeffs);
+        let poly = Polynomial::interpolate(omegas, &evals).map_err(|e| e.to_string())?;
+        coeff_vecs.push(poly.into_coeffs());
     }
     Ok(coeff_vecs)
 }


### PR DESCRIPTION
## Description
Threshold sig will need a polynomial evaluation function so the `interpolate` and `evaluate` logic was merged under a new `Polynomial` struct that holds the coefficients of a polynomial.

The first implementation used const generics, i.e. a `Polynomial<const N: usize, T>` had a compile-time parameter: the order of the polynomial. This meant that the coefficients were stored in a `[T; N + 1]` array. Even though this provided nice compile-time size bounds, it is too static for our usecases. For example, when generating a ring signature, we don't know the ring's size beforehand, and even if we did, it probably changes with every call. That means, however, that the code would have to be recompiled with the known ring size as a constant at every call, which is nonsensical. Even for threshold signatures, with participants entering/leaving the network, the static size bounds would have to be recompiled. So we are rolling with dynamic `Vec<T>` types instead.

Aims to close #46 